### PR TITLE
feat(polar): implement basic feature

### DIFF
--- a/demo/chart.js
+++ b/demo/chart.js
@@ -212,7 +212,7 @@ var billboardDemo = {
 
 		// UMD
 		code.data = code.data.join("")
-			.replace(/"(area|area-line-range|area-spline|area-spline-range|area-step|bar|bubble|candlestick|donut|gauge|line|pie|radar|scatter|spline|step|selection|subchart|zoom)(\(\))?",?/g, function(match, p1, p2, p3, offset, string) {
+			.replace(/"(area|area-line-range|area-spline|area-spline-range|area-step|bar|bubble|candlestick|donut|gauge|line|pie|polar|radar|scatter|spline|step|selection|subchart|zoom)(\(\))?",?/g, function(match, p1, p2, p3, offset, string) {
 				var module = camelize(p1);
 		
 				code.esm.indexOf(module) === -1 &&

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -569,6 +569,24 @@ var demos = {
 				]
 			}
 		},
+		PolarChart: {
+			options: {
+				data: {
+					columns: [
+						["data1", 30],
+						["data2", 120],
+						["data3", 75]
+					],
+					type: "polar",
+					labels: true
+				},
+				polar: {
+					level:{
+						depth: 4,
+					},
+				}
+			}
+		},
 		RadarChart: {
 			options: {
 				data: {

--- a/demo/index.html
+++ b/demo/index.html
@@ -135,6 +135,7 @@
                             <li><a href="#Chart.GaugeChart">Gauge</a></li>
                             <li><a href="#Chart.LineChart">Line</a></li>
                             <li><a href="#Chart.PieChart">Pie</a></li>
+                            <li><a href="#Chart.PolarChart">Polar</a></li>
                             <li><a href="#Chart.RadarChart">Radar</a></li>
                             <li><a href="#Chart.ScatterPlot">Scatter</a></li>
                             <li><a href="#Chart.SplineChart">Spline</a></li>

--- a/demo/types/types.js
+++ b/demo/types/types.js
@@ -13,6 +13,7 @@ const Types = {
         "spline",
         "step",
         "candlestick",
+        "polar",
         "radar",
         "gauge",
         "gauge-multi",

--- a/src/ChartInternal/ChartInternal.ts
+++ b/src/ChartInternal/ChartInternal.ts
@@ -181,6 +181,7 @@ export default class ChartInternal {
 
 		state.hasAxis = !$$.hasArcType();
 		state.hasRadar = !state.hasAxis && $$.hasType("radar");
+		state.hasPolar = !state.hasAxis && $$.hasType("polar");
 
 		$$.initParams();
 
@@ -490,7 +491,7 @@ export default class ChartInternal {
 	 */
 	initChartElements(): void {
 		const $$ = <any> this;
-		const {hasAxis, hasRadar} = $$.state;
+		const {hasAxis, hasRadar, hasPolar} = $$.state;
 		const types: string[] = [];
 
 		if (hasAxis) {
@@ -502,7 +503,7 @@ export default class ChartInternal {
 				}
 			});
 		} else {
-			if (!hasRadar) {
+			if (!hasRadar && !hasPolar) {
 				types.push("Arc", "Pie");
 			}
 
@@ -510,6 +511,8 @@ export default class ChartInternal {
 				types.push("Gauge");
 			} else if (hasRadar) {
 				types.push("Radar");
+			} else if (hasPolar) {
+				types.push("Polar");
 			}
 		}
 
@@ -589,7 +592,7 @@ export default class ChartInternal {
 	 */
 	updateTargets(targets): void {
 		const $$ = <any> this;
-		const {hasAxis, hasRadar} = $$.state;
+		const {hasAxis, hasRadar, hasPolar} = $$.state;
 
 		// Text
 		$$.updateTargetsForText(targets);
@@ -609,11 +612,13 @@ export default class ChartInternal {
 			$$.updateTargetsForSubchart &&
 				$$.updateTargetsForSubchart(targets);
 		} else {
-			// Arc & Radar
+			// Arc & Radar & Polar
 			$$.hasArcType(targets) && (
 				hasRadar ?
 					$$.updateTargetsForRadar(targets.filter($$.isRadarType.bind($$))) :
-					$$.updateTargetsForArc(targets.filter($$.isArcType.bind($$)))
+					hasPolar ?
+						$$.updateTargetsForPolarArc(targets.filter($$.isPolarType.bind($$))) :
+						$$.updateTargetsForArc(targets.filter($$.isArcType.bind($$)))
 			);
 		}
 

--- a/src/ChartInternal/internals/redraw.ts
+++ b/src/ChartInternal/internals/redraw.ts
@@ -86,6 +86,9 @@ export default {
 
 			// radar
 			$el.radar && $$.redrawRadar();
+
+			// polar
+			$el.polar && $$.redrawPolar();
 		}
 
 		// @TODO: Axis & Radar type

--- a/src/ChartInternal/internals/transform.ts
+++ b/src/ChartInternal/internals/transform.ts
@@ -5,7 +5,7 @@
 import CLASS from "../../config/classes";
 import {asHalfPixel} from "../../module/util";
 
-type TranslateParam = "main" | "context" | "legend" | "x" | "y" | "y2" | "subX" | "arc" | "radar";
+type TranslateParam = "main" | "context" | "legend" | "x" | "y" | "y2" | "subX" | "arc" | "radar" | "polar";
 
 export default {
 	getTranslate(target: TranslateParam, index = 0): string {
@@ -42,6 +42,9 @@ export default {
 			x = 0;
 			y = isRotated ? 0 : state.height2;
 		} else if (target === "arc") {
+			x = state.arcWidth / 2;
+			y = state.arcHeight / 2;
+		} else if (target === "polar") {
 			x = state.arcWidth / 2;
 			y = state.arcHeight / 2;
 		} else if (target === "radar") {

--- a/src/ChartInternal/internals/type.ts
+++ b/src/ChartInternal/internals/type.ts
@@ -187,6 +187,10 @@ export default {
 		return this.isTypeOf(d, "donut");
 	},
 
+	isPolarType(d): boolean {
+		return this.isTypeOf(d, "polar");
+	},
+
 	isRadarType(d): boolean {
 		return this.isTypeOf(d, "radar");
 	},
@@ -195,6 +199,7 @@ export default {
 		return this.isPieType(d) ||
 			this.isDonutType(d) ||
 			this.isGaugeType(d) ||
+			this.isPolarType(d) ||
 			this.isRadarType(d);
 	},
 

--- a/src/ChartInternal/shape/polar.ts
+++ b/src/ChartInternal/shape/polar.ts
@@ -1,0 +1,131 @@
+import {arc as d3Arc, pie as d3Pie} from "d3-shape";
+import CLASS from "../../config/classes";
+import {getRange} from "../../module/util";
+
+export default {
+	initPolar(): void {
+		const $$ = this;
+		const {config, state: {current}, $el} = $$;
+		const depth = config.polar_level_depth;
+
+		$el.polar = $el.main.select(`.${CLASS.chart}`).append("g")
+			.attr("class", CLASS.chartPolars);
+
+		// level
+		$el.polar.levels = $el.polar.append("g")
+			.attr("class", CLASS.levels);
+
+		// arcs
+		$el.polar.arcs = $el.polar.append("g")
+			.attr("class", CLASS.chartPolarArcs);
+
+		// Let every data is less or equal to dataMax and each level has integer value
+		current.dataMax = Math.ceil($$.getMinMaxData().max[0].value / depth) * depth;
+
+		$$.polarPie = d3Pie().value(1);
+	},
+
+	getPolarSize(): [number, number] {
+		const $$ = this;
+		const {state: {arcWidth, arcHeight}} = $$;
+		const size = (Math.min(arcWidth, arcHeight) - 10) / 2;
+
+		return [size, size];
+	},
+
+	getPolarArc(d): string {
+		const $$ = this;
+		const {state: {current}} = $$;
+		const [width, height] = $$.getPolarSize();
+		const radius = Math.min(width, height);
+
+		return d3Arc()
+			.innerRadius(0)
+			.outerRadius((d: any) => d.data.values.reduce((a, b) => a + b.value, 0) / current.dataMax * radius)(d) || "M 0 0";
+	},
+
+	updateTargetsForPolarArc(targets): void {
+		const $$ = this;
+		const {$el} = $$;
+
+		const classChartArc = $$.getChartClass("Arc");
+		const classArcs = $$.getClass("arcs", true);
+		const classFocus = $$.classFocus.bind($$);
+		const chartArcs = $el.polar.arcs;
+
+		const mainPieUpdate = chartArcs
+			.selectAll(`.${CLASS.chartArc}`)
+			.data($$.polarPie(targets))
+			.attr("class", d => classChartArc(d) + classFocus(d.data));
+
+		const mainPieEnter = mainPieUpdate.enter().append("g")
+			.attr("class", classChartArc);
+
+		mainPieEnter.append("g")
+			.attr("class", classArcs)
+			.merge(mainPieUpdate);
+	},
+
+	redrawPolar(): void {
+		const $$ = this;
+		const {polar} = $$.$el;
+		const translate = $$.getTranslate("polar");
+
+		if (translate) {
+			polar.attr("transform", translate);
+
+			$$.updatePolarLevel();
+		}
+
+		let mainArc = polar.arcs
+			.selectAll(`.${CLASS.arcs}`)
+			.selectAll(`.${CLASS.arc}`)
+			.data($$.arcData.bind($$));
+
+		mainArc.exit().remove();
+
+		mainArc = mainArc.enter().append("path")
+			.attr("class", $$.getClass("arc", true))
+			.style("fill", d => $$.color(d.data))
+			.each(function(d) { this._current = d; })
+			.merge(mainArc)
+			.attr("d", d => $$.getPolarArc(d));
+	},
+
+
+	updatePolarLevel(): void {
+		const $$ = this;
+		const {config, state, $el: {polar}} = $$;
+		const [width, height] = $$.getPolarSize();
+		const depth = config.polar_level_depth;
+
+		const polarLevels = polar.levels;
+		const levelData = getRange(0, depth);
+
+		const radius = Math.min(width, height);
+		const levelRatio = levelData.map(l => radius * ((l + 1) / depth));
+
+		const level = polarLevels
+			.selectAll(`.${CLASS.level}`)
+			.data(levelData);
+
+		level.exit().remove();
+
+		const levelEnter = level.enter().append("g")
+			.attr("class", (d, i) => `${CLASS.level} ${CLASS.level}-${i}`);
+
+		// cx, cy, translate: Set center as origin (0,0) so that it can share same center with arcs
+		levelEnter.append("circle")
+			.attr("cx", 0)
+			.attr("cy", 0)
+			.attr("r", d => levelRatio[d]);
+
+		levelEnter.append("text")
+			.style("text-anchor", "middle")
+			.attr("dy", "0.5rem")
+			.attr("transform", d => `translate(0, ${-levelRatio[d]})`)
+			.text(d => state.current.dataMax / levelData.length * (d + 1));
+
+		levelEnter.merge(level);
+	},
+};

--- a/src/ChartInternal/shape/polar.ts
+++ b/src/ChartInternal/shape/polar.ts
@@ -22,6 +22,8 @@ export default {
 		// Let every data is less or equal to dataMax and each level has integer value
 		current.dataMax = Math.ceil($$.getMinMaxData().max[0].value / depth) * depth;
 
+		// Let each value be 1, thus every arc has same central angle
+		// To match central angle with specific data, change "1" to specific function.
 		$$.polarPie = d3Pie().value(1);
 	},
 

--- a/src/config/Options/shape/polar.ts
+++ b/src/config/Options/shape/polar.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2017 ~ present NAVER Corp.
+ * billboard.js project is licensed under the MIT license
+ */
+/**
+ * x Axis config options
+ */
+export default {
+	/**
+	 * Set polar options
+	 * - **NOTE:**
+	 *  > When x tick text contains `\n`, it's used as line break.
+	 * @name polar
+	 * @memberof Options
+	 * @type {object}
+	 * @property {object} polar Polar object
+	 * @property {number} [polar.level.depth=3] Set the level depth.
+	 * @see [Demo](https://naver.github.io/billboard.js/demo/#Chart.PolarChart)
+	 * @example
+	 *  polar: {
+	 * 		level: {
+	 * 			depth: 3
+	 * 		}
+	 *  }
+	 */
+	polar_level_depth: 3,
+};

--- a/src/config/classes.ts
+++ b/src/config/classes.ts
@@ -42,6 +42,8 @@ export default {
 	chartCircles: "bb-chart-circles",
 	chartLine: "bb-chart-line",
 	chartLines: "bb-chart-lines",
+	chartPolarArcs: "bb-chart-polararcs",
+	chartPolars: "bb-chart-polars",
 	chartRadar: "bb-chart-radar",
 	chartRadars: "bb-chart-radars",
 	chartText: "bb-chart-text",

--- a/src/config/const.ts
+++ b/src/config/const.ts
@@ -19,6 +19,7 @@ export const TYPE = {
 	GAUGE: "gauge",
 	LINE: "line",
 	PIE: "pie",
+	POLAR: "polar",
 	RADAR: "radar",
 	SCATTER: "scatter",
 	SPLINE: "spline",
@@ -68,6 +69,7 @@ export const TYPE_BY_CATEGORY = {
 		TYPE.PIE,
 		TYPE.DONUT,
 		TYPE.GAUGE,
+		TYPE.POLAR,
 		TYPE.RADAR
 	],
 	Line: [

--- a/src/config/resolver/shape.ts
+++ b/src/config/resolver/shape.ts
@@ -24,6 +24,7 @@ import shapeGauge from "../../ChartInternal/shape/gauge";
 import shapeBubble from "../../ChartInternal/shape/bubble";
 import shapeLine from "../../ChartInternal/shape/line";
 import shapePoint from "../../ChartInternal/shape/point";
+import shapePolar from "../../ChartInternal/shape/polar";
 import shapeRadar from "../../ChartInternal/shape/radar";
 
 // Options
@@ -40,6 +41,7 @@ import optSpline from "../Options/shape/spline";
 import optDonut from "../Options/shape/donut";
 import optGauge from "../Options/shape/gauge";
 import optPie from "../Options/shape/pie";
+import optPolar from "../Options/shape/polar";
 import optRadar from "../Options/shape/radar";
 
 export {
@@ -55,6 +57,7 @@ export {
 	gauge,
 	line,
 	pie,
+	polar,
 	radar,
 	scatter,
 	spline,
@@ -121,6 +124,7 @@ let step = (): string => (extendLine(), (step = () => TYPE.STEP)());
 let donut = (): string => (extendArc(undefined, [optDonut]), (donut = () => TYPE.DONUT)());
 let gauge = (): string => (extendArc([shapeGauge], [optGauge]), (gauge = () => TYPE.GAUGE)());
 let pie = (): string => (extendArc(undefined, [optPie]), (pie = () => TYPE.PIE)());
+let polar = (): string => (extendArc([shapePolar], [optPolar]), (polar = () => TYPE.POLAR)());
 let radar = (): string => (
 	extendArc([shapePoint, shapeRadar], [optPoint, optRadar]), (radar = () => TYPE.RADAR)()
 );

--- a/src/core.ts
+++ b/src/core.ts
@@ -70,6 +70,7 @@ const bb = {
 	 *   gauge,
 	 *   line,
 	 *   pie,
+	 * 	 polar,
 	 *   radar,
 	 *   scatter,
 	 *   spline,

--- a/src/core.ts
+++ b/src/core.ts
@@ -70,7 +70,7 @@ const bb = {
 	 *   gauge,
 	 *   line,
 	 *   pie,
-	 * 	 polar,
+	 *   polar,
 	 *   radar,
 	 *   scatter,
 	 *   spline,

--- a/src/index.esm.ts
+++ b/src/index.esm.ts
@@ -16,6 +16,7 @@ export {
 	gauge,
 	line,
 	pie,
+	polar,
 	radar,
 	scatter,
 	spline,

--- a/src/scss/billboard.scss
+++ b/src/scss/billboard.scss
@@ -298,6 +298,27 @@
 	}
 }
 
+/*-- Polar --*/
+.bb-chart-polars {
+	.bb-levels {
+		circle {
+			fill: none;
+			stroke: #848282;
+			stroke-width: .5px;
+		}
+
+		text {
+			fill: #848282;
+		}
+	}
+
+	.bb-shapes {
+		path {
+			stroke-width: 1px;
+		}
+	}
+}
+
 /*-- Button --*/
 .bb-button {
 	position: absolute;


### PR DESCRIPTION
# Issue
#2 #3 #4 #11 

# Details
## 구현 기능

- 데이터 입력, 차트 출력
    - y축에 해당하는 원형 level
    - 반지름으로 값을 표현하는 arc
- 디자인은 [https://www.chartjs.org/docs/latest/charts/polar.html](https://www.chartjs.org/docs/latest/charts/polar.html) 참조, 축 색 등은 Radar 값 재활용
- 데모에 Polar Chart 추가

## 구현 과정

src/ChartInternal/shape 의 radar.ts와 arc.ts를 동시참조하여 필요한 기능만 가져옴
- arc.ts의 경우
    - Donut, Pie 등 각종 배리언트를 내장, Gauge에 대한 공통 처리를 포함하고 있어 불필요한 코드가 많음
    - Polar를 위 경우와 동일시하기에는 다음과 같은 문제가 있음
        1. arc.ts는 d3의 pie (이하 d3Pie)를 활용하고 있는데, 이는 기본적으로 데이터 내 value를 ratio로 환산하여 arc의 중심각을 지정해버림. 따라서 d3Pie의 .value 설정을 Polar의 경우 별도 처리해주어야 함
        2. 동일하게 outerRadius에 대한 설정도 특수하게 변환해주어야 함
        3. level도 또 따로 그려주어야 함
    - Gauge와 같이 추가적인 설정만 하고 대부분의 코드를 arc.ts에서 참조하는 방식을 택하더라도 위의 1, 2는 해결되지 않음
- radar.ts의 경우
    - 데이터 표현이 기본적으로 points로 되어있기 때문에 이에 관한 코드가 뒤섞여있음
- 또한 두 파일 모두 클릭 또는 호버 이벤트와 같은 추가적(인 줄 알았으나 기본인데 누락한) 기능들에 대한 코드가 있어 이해하는 데에만 한참 걸릴 것으로 판단

## 구현 상세

### demo/
- Polar 추가
### src/ChartInternal/shape/polar.ts
- initPolar
    - 아래 구조로 g 태그 생성
        > CLASS.chartPolars
        ㄴ CLASS.levels
        ㄴ CLASS.chartPolarArcs
        > 
    - 최대 값 설정
        - 가장 큰 값보다 크거나 같은 depth의 배수 중 가장 작은 값
        - 각 level이 정수가 되도록 하기 위함 (별 이유 없이 그냥 그게 보기 좋아서 그렇게 함)
        - chart.js의 경우 간격이나 level 수를 따로 지정할 수 없게 되어있어 나름의 규칙으로 해결한 것으로 보임
        - 나중에는 최대 값도 옵션으로 받게 할 수도 있을 듯
    - d3Pie 초기화
        - value를 1으로 고정하여 각 arc가 동일한 중심각을 갖도록 설정
- getPolarSize: radar 참조, padding은 원형이므로 10으로 고정
- getPolarArc
    - 최대 값과 value의 비율을 반지름으로 환산하여 d3 arc의 outerRadius로 지정 후 반환
        - value의 계산은 arc.ts의 $$.pie 정의 참조
- updateTargetsForPolarArc
    - 주로 arc.ts 참조
    - $el.polar.arcs 안쪽에만 적용해야 하여 chartArcs의 정의만 변경
        - 클래스명으로도 구분은 되지만 앞서 선언해둔 것과 통일성을 위해 이렇게 불러옴
- redrawPolar
    - src/ChartInternal/internals/transform.ts 에 정의한 getTranslate("polar")에 따라 이동
        - 위 좌표 이동에 대한 내용은 후술
    - arcs 추가
        - 주로 arc.ts 참조, transition 제외, text 제외
        - CLASS.arc를 찾아서 데이터 바인드 후, exit - remove / enter - append로 노드 수 재조정, path의 d 속성 지정을 통해 getPolarArc 결과 전달
- updatePolarLevel
    - radar.ts 참조, transition 제외, 좌표계 관련 수정
        - 각 노드를 다루는 부분은 위와 유사
    - 각 circle을 처음부터 중심에 두지 않고 무조건 0,0을 중심으로 하도록 재조정
        - redrawPolar에서 언급한 좌표 이동과 연관
    - text도 유사하게 transform 변경

### src/ChartInternal/internals/transform.ts
- target === "polar" 인 경우는 target === "arc"인 경우와 동일하게 처리
    - 각 arc들을 level circle의 중심 위치로 이동시킨 후 radar와 같은 방식으로 전체 이동을 시키는 것보다 처음부터 level circle을 0,0에 그리고 arc와 동일하게 한 번만 전체 이동을 하는 것이 더 낫다고 판단하였음

### src/config/Options/shape/polar.ts
- level.depth만 넣어둠
- radar와 pie 참고하면서 필요한 옵션을 포함하는 입력 형식을 정하는 것이 최우선으로 진행되어야 할 것 같음

### src/scss/billboard.scss
- radar 스타일에서 axis 삭제, shapes를 polygon에서 path로 변경

### 그 외
- 최소한으로 넣으려고 했으나 한 번 정도 확인 필요

## 알아두면 좋은 내용
- 생각보다 많은 $$의 메소드들이 전역으로 선언되어 있는건지 아니면 전부 import 하면서 그런건지 모르겠으나 이름이 겹치면 꼬이는 경우가 적지 않다

## 확인 필요
- src/ChartInternal/shape/polar.ts
    - `initPolar` -> radar.ts > initRadar에서는 hasType("radar") 여부를 확인하는데 이유를 모르겠음. polar에서는 따로 hasType("polar")를 확인하지 않고 있으나 아직은 큰 문제 없는데 확인 필요
    - 중구난방한 object property 호출 개선
        - `const {polar} = $$.$el;` / `const {$el: {polar}} = $$;` / `const {$el} = $$; $el.polar` 등등...
- src/Chart/api/focus.ts -> focus, defocus, revert에 대해서 별도 구현 필요
    - 현재는 arc.ts의 expand/unexpand를 따르게 되어있어서 이상하게 작동할 것
- src/ChartInternal/ChartInternal.ts: 615~622 -> 일단 써놨으나 개선 필요
- src/config/classes.ts -> 클래스 이름 임시로 설정했으므로 개선 여부 확인 필요
- src/config/const.ts > TYPE_METHOD_NEEDED -> 의미를 이해하지 못해서 Polar는 일단 스킵. 굳이 따지자면 initArc인 듯 하나 의미를 이해한 후 추가해도 될 것 같음
- 커밋이 coverage 테스트를 통과하지 못 했기 때문에 확인 및 개선 필요