### PR TITLE
feat(polar): implement mouse events

### DIFF
--- a/src/Chart/api/focus.ts
+++ b/src/Chart/api/focus.ts
@@ -79,7 +79,7 @@ export default {
 		candidates.classed(CLASS.focused, false).classed(CLASS.defocused, true);
 
 		if ($$.hasArcType()) {
-			$$.unexpandArc(targetIds);
+			state.hasPolar ? $$.unexpandPolar(targetIds) : $$.unexpandArc(targetIds);
 
 			$$.hasType("gauge") &&
 				$$.undoMarkOverlapped($$, `.${CLASS.gaugeValue}`);
@@ -115,7 +115,10 @@ export default {
 		const candidates = $el.svg.selectAll($$.selectorTargets(targetIds)); // should be for all targets
 
 		candidates.classed(CLASS.focused, false).classed(CLASS.defocused, false);
-		$$.hasArcType() && $$.unexpandArc(targetIds);
+
+		if ($$.hasArcType()) {
+			state.hasPolar ? $$.unexpandPolar(targetIds) : $$.unexpandArc(targetIds);
+		}
 
 		if (config.legend_show) {
 			$$.showLegend(targetIds.filter($$.isLegendToShow.bind($$)));

--- a/src/ChartInternal/internals/format.ts
+++ b/src/ChartInternal/internals/format.ts
@@ -39,10 +39,13 @@ export default {
 	getDefaultValueFormat(): Function {
 		const $$ = this;
 		const hasArc = $$.hasArcType();
+		const {hasPolar} = $$.state;
 
-		return hasArc && !$$.hasType("gauge") ?
-			$$.defaultArcValueFormat :
-			$$.defaultValueFormat;
+		return hasPolar ?
+			$$.defaultPolarValueFormat :
+			hasArc && !$$.hasType("gauge") ?
+				$$.defaultArcValueFormat :
+				$$.defaultValueFormat;
 	},
 
 	defaultValueFormat(v): number|string {
@@ -51,6 +54,10 @@ export default {
 
 	defaultArcValueFormat(v, ratio): string {
 		return `${(ratio * 100).toFixed(1)}%`;
+	},
+
+	defaultPolarValueFormat(v): string {
+		return `${v}`;
 	},
 
 	dataLabelFormat(targetId: string): Function {

--- a/src/scss/billboard.scss
+++ b/src/scss/billboard.scss
@@ -302,7 +302,9 @@ text.bb-chart-arcs-gauge-title {
 
 	.bb-shapes {
 		path {
-			stroke-width: 1px;
+			fill-opacity: .6;
+			stroke-width: .5px;
+			stroke-opacity: .5;
 		}
 	}
 }


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#8 , #4

## Details
<!-- Detailed description of the change/feature -->
### 영상

https://user-images.githubusercontent.com/40665154/144716491-bf30db20-5ece-434e-9f3f-12477ff2fe70.mov

### 작업 내용
- `arc.ts`의 mouse 관련 이벤트 코드들을 참고하여 `polar.ts`에 추가하였습니다. 
-  `focus.ts`에서 polar 타입을 확인하여 `polar.ts`의 method들이 호출되도록 하였습니다. 
- polar의 tooltip에서 활용할 수 있도록 `defaultPolarValueFormat`을 추가했습니다. 
- (+) 디폴트로 area 뒤쪽에 level line이 보이도록 수정했습니다.
